### PR TITLE
Fixed populating bible chapter and sunday homily month when editing

### DIFF
--- a/components/EditSermonForm.tsx
+++ b/components/EditSermonForm.tsx
@@ -8,8 +8,8 @@ import { useCollectionDataOnce } from 'react-firebase-hooks/firestore';
 import { collection } from 'firebase/firestore';
 import firestore from '../firebase/firestore';
 import { listConverter } from '../types/List';
-// import Box from '@mui/material/Box';
-// import CircularProgress from '@mui/material/CircularProgress';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
 
 interface EditSermonFormInfo {
   open: boolean;
@@ -18,20 +18,20 @@ interface EditSermonFormInfo {
 }
 
 const EditSermonForm = ({ sermon, open, setOpen }: EditSermonFormInfo) => {
-  const [sermonLists, _loading, _error, _snapshot] = useCollectionDataOnce(
+  const [sermonLists, loading, error, _snapshot] = useCollectionDataOnce(
     collection(firestore, `sermons/${sermon.id}/sermonLists`).withConverter(listConverter)
   );
 
   return (
     <Dialog open={open} onClose={() => setOpen(false)} aria-labelledby="confirm-dialog" maxWidth="lg">
       <DialogContent>
-        {/* {error ? (
+        {error ? (
           <Box>{error.message}</Box>
         ) : loading ? (
           <CircularProgress />
-        ) : ( */}
+        ) : (
         <Uploader existingSermon={sermon} existingList={sermonLists || []} setEditFormOpen={setOpen} />
-        {/* )} */}
+         )}
       </DialogContent>
       <DialogActions>
         <Button

--- a/types/List.ts
+++ b/types/List.ts
@@ -19,6 +19,14 @@ export enum ListTag {
   SUNDAY_HOMILY_MONTH = 'sunday-homily-month',
 }
 
+export interface SundayHomiliesMonthList extends List {
+  listTagAndPosition: Extract<ListTagAndPostionType, {listTag: ListTag.SUNDAY_HOMILY_MONTH}>
+}
+
+export interface BibleStudyList extends List {
+  listTagAndPosition: Extract<ListTagAndPostionType, {listTag: ListTag.BIBLE_CHAPTER}>
+}
+
 export type ListTagAndPostionType =
   | {
       listTag: ListTag.BIBLE_CHAPTER;


### PR DESCRIPTION
BEFORE FIX
- The sunday homily month and bible chapter dropdowns were null when editing even if the original sermon had them

AFTER FIX
- The sunday homily month and bible chapter dropdowns are now populated with the previously selected content when editing