### PR TITLE
Fix sermon list on update

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,11 +18,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": [
-    "react",
-    "@typescript-eslint",
-    "mui"
-  ],
+  "plugins": ["react", "@typescript-eslint", "mui"],
   "rules": {
     "no-restricted-imports": [
       "error",
@@ -47,9 +43,12 @@
         "caughtErrorsIgnorePattern": "^_"
       }
     ],
-    "react-hooks/exhaustive-deps": ["warn", {
-      "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)"
-    }]
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)"
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/components/AdminSermonsList.tsx
+++ b/components/AdminSermonsList.tsx
@@ -5,21 +5,21 @@ import { useCollection } from 'react-firebase-hooks/firestore';
 import SermonsList from './SermonsList';
 import { sermonConverter } from '../types/Sermon';
 import SermonListSkeloten from './skeletons/SermonListSkeloten';
-import { FunctionComponent, useCallback, useEffect, useState } from 'react';
-import TextField from '@mui/material/TextField';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import Select from '@mui/material/Select';
-import MenuItem from '@mui/material/MenuItem';
+import { FunctionComponent, useState } from 'react';
+// import TextField from '@mui/material/TextField';
+// import FormControl from '@mui/material/FormControl';
+// import InputLabel from '@mui/material/InputLabel';
+// import Select from '@mui/material/Select';
+// import MenuItem from '@mui/material/MenuItem';
 import { Sermon } from '../types/SermonTypes';
-import algoliasearch from 'algoliasearch';
-import { createInMemoryCache } from '@algolia/cache-in-memory';
-import Checkbox from '@mui/material/Checkbox';
-import ListItemText from '@mui/material/ListItemText';
+// import algoliasearch from 'algoliasearch';
+// import { createInMemoryCache } from '@algolia/cache-in-memory';
+// import Checkbox from '@mui/material/Checkbox';
+// import ListItemText from '@mui/material/ListItemText';
 import { User, UserRole } from '../types/User';
 import Button from '@mui/material/Button';
 import UserRoleGuard from './UserRoleGuard';
-import { useInstantSearch } from 'react-instantsearch';
+import Link from '@mui/material/Link';
 
 interface AdminSermonsListProps {
   collectionPath: string;
@@ -32,25 +32,24 @@ interface AdminSermonsListWithUserProps extends AdminSermonsListProps {
 
 const HITSPERPAGE = 20;
 
-const client =
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID && process.env.NEXT_PUBLIC_ALGOLIA_API_KEY
-    ? algoliasearch(process.env.NEXT_PUBLIC_ALGOLIA_APP_ID, process.env.NEXT_PUBLIC_ALGOLIA_API_KEY, {
-        responsesCache: createInMemoryCache(),
-        requestsCache: createInMemoryCache({ serializable: false }),
-      })
-    : undefined;
-const sermonsIndex = client?.initIndex('sermons');
-const limitCount = 20;
+// const client =
+//   process.env.NEXT_PUBLIC_ALGOLIA_APP_ID && process.env.NEXT_PUBLIC_ALGOLIA_API_KEY
+//     ? algoliasearch(process.env.NEXT_PUBLIC_ALGOLIA_APP_ID, process.env.NEXT_PUBLIC_ALGOLIA_API_KEY, {
+//         responsesCache: createInMemoryCache(),
+//         requestsCache: createInMemoryCache({ serializable: false }),
+//       })
+//     : undefined;
+// const sermonsIndex = client?.initIndex('sermons');
 
 const AdminSermonsListWithUser: FunctionComponent<AdminSermonsListWithUserProps> = ({
   collectionPath,
   count,
   user,
 }) => {
-  const [queryLimit, setQueryLimit] = useState<number>(limitCount);
+  const [queryLimit, setQueryLimit] = useState<number>(HITSPERPAGE);
   const [previousSermonsCount, setPreviousSermonsCount] = useState<number>(0);
   const [previousSermons, setPreviousSermons] = useState<Sermon[]>([]);
-  const { status } = useInstantSearch();
+  // const [algoliaLoading, setAlgoliaLoading] = useState(false);
 
   const sermonsRef = collection(firestore, collectionPath);
   const q =
@@ -58,6 +57,7 @@ const AdminSermonsListWithUser: FunctionComponent<AdminSermonsListWithUserProps>
       ? query(
           sermonsRef.withConverter(sermonConverter),
           where('uploaderId', '==', user.uid),
+          orderBy('dateMillis', 'desc'),
           orderBy('createdAtMillis', 'desc'),
           limit(queryLimit)
         )
@@ -69,51 +69,64 @@ const AdminSermonsListWithUser: FunctionComponent<AdminSermonsListWithUserProps>
     // eslint-disable-next-line no-console
     console.error(error);
   }
-  const [searchQuery, setSearchQuery] = useState('');
-  const [currentPage, setCurrentPage] = useState(0);
-  const [searchResults, setSearchResults] = useState<Sermon[]>();
-  const [noMoreResults, setNoMoreResults] = useState(false);
-  const [filters, setFilters] = useState<string[]>([]);
+  // const [searchQuery, setSearchQuery] = useState('');
+  // const [currentPage, setCurrentPage] = useState(0);
+  // const [searchResults, setSearchResults] = useState<Sermon[]>();
+  // const [noMoreResults, setNoMoreResults] = useState(false);
+  // const [filters, setFilters] = useState<string[]>([]);
 
-  const searchLists = useCallback(
-    async (query?: string) => {
-      const res = await sermonsIndex?.search<Sermon>(query || searchQuery, {
-        hitsPerPage: HITSPERPAGE,
-        page: currentPage,
-        ...(user.role !== UserRole.ADMIN && { filters: `uploaderId:${user.uid}` }),
-        ...(filters.length !== 0 && { facetFilters: [filters.map((filter) => `${filter}`)] }),
-      });
-      if (res && res.hits.length > 0) {
-        setNoMoreResults(false);
-        setSearchResults(res.hits);
-      } else {
-        setNoMoreResults(true);
-        setSearchResults([]);
-      }
-    },
-    [currentPage, filters, searchQuery, user?.role, user?.uid]
-  );
+  // IN ORDER TO DO SEARCH WE FIRST NEED TO FIGURE OUT HOW TO ONLY SEARCH ITEMS FROM THIS LIST AND NOT ALL ITEMS
+  // const searchLists = useCallback(
+  //   async (query?: string) => {
+  //     setAlgoliaLoading(true);
+  //     const res = await sermonsIndex?.search<Sermon>(query || searchQuery, {
+  //       hitsPerPage: HITSPERPAGE,
+  //       page: currentPage,
+  //       ...(user.role !== UserRole.ADMIN && { filters: `uploaderId:${user.uid}` }),
+  //       ...(filters.length !== 0 && { facetFilters: [filters.map((filter) => `${filter}`)] }),
+  //     });
+  //     if (res && res.hits.length > 0) {
+  //       setNoMoreResults(false);
+  //       setSearchResults(res.hits);
+  //     } else {
+  //       setNoMoreResults(true);
+  //       setSearchResults([]);
+  //     }
+  //     setAlgoliaLoading(false);
+  //   },
+  //   [currentPage, filters, searchQuery, user?.role, user?.uid]
+  // );
 
-  useEffect(() => {
-    const fetchData = async () => {
-      if (!(filters.length === 0 && searchQuery === '')) {
-        await searchLists();
-      }
-    };
-    fetchData();
-  }, [currentPage, filters, searchLists, searchQuery]);
+  // useEffect(() => {
+  //   const fetchData = async () => {
+  //     if (!(filters.length === 0 && searchQuery === '')) {
+  //       await searchLists();
+  //     }
+  //   };
+  //   fetchData();
+  // }, [currentPage, filters, searchLists, searchQuery]);
 
-  const filterOptions = [
-    { value: 'status.soundCloud:NOT_UPLOADED', label: 'Not Uploaded on SoundCloud' },
-    { value: 'status.soundCloud:UPLOADED', label: 'Uploaded on SoundCloud' },
-    { value: 'status.subsplash:NOT_UPLOADED', label: 'Not Uploaded on Subsplash' },
-    { value: 'status.subsplash:UPLOADED', label: 'Uploaded on Subsplash' },
-  ];
+  // const filterOptions = [
+  //   { value: 'status.soundCloud:NOT_UPLOADED', label: 'Not Uploaded on SoundCloud' },
+  //   { value: 'status.soundCloud:UPLOADED', label: 'Uploaded on SoundCloud' },
+  //   { value: 'status.subsplash:NOT_UPLOADED', label: 'Not Uploaded on Subsplash' },
+  //   { value: 'status.subsplash:UPLOADED', label: 'Uploaded on Subsplash' },
+  // ];
 
   return (
     <Box width="100%" display="flex" flexDirection="column" alignItems="center" gap="10px" padding={3}>
-      <Typography variant="h3">Manage Sermons</Typography>
-      <Box display="flex" width="100%" justifyContent="space-between">
+      <Box display="flex" width={1}>
+        <Box display="flex" sx={{ flex: 1, alignItems: 'center', justifyContent: 'left' }}>
+          <Link href="/admin/lists">
+            <Button variant="contained" disableRipple>
+              Back
+            </Button>
+          </Link>
+        </Box>
+        <Typography variant="h3">Manage Sermons</Typography>
+        <Box sx={{ flex: 1 }} />
+      </Box>
+      {/* <Box display="flex" width="100%" justifyContent="space-between">
         <TextField
           placeholder="Search a for a sermon by name, subtitle, speaker, or description"
           onChange={async (e) => {
@@ -167,7 +180,7 @@ const AdminSermonsListWithUser: FunctionComponent<AdminSermonsListWithUserProps>
             </Select>
           </FormControl>
         </Box>
-      </Box>
+      </Box> */}
       {error && (
         <Typography component="div">
           <Box fontWeight="bold" display="inline">
@@ -175,40 +188,32 @@ const AdminSermonsListWithUser: FunctionComponent<AdminSermonsListWithUserProps>
           </Box>
         </Typography>
       )}
-      {status === 'error' && (
-        <Typography component="div">
-          <Box fontWeight="bold" display="inline">
-            Error: Algolia search errored please try again later
-          </Box>
-        </Typography>
-      )}
-      {(loading || status === 'loading' || status === 'stalled') && (
+      {loading && (
         <>
           <SermonsList sermons={previousSermons} />
           <SermonListSkeloten count={count} />
         </>
       )}
-      {searchResults ? (
-        <SermonsList sermons={searchResults} />
-      ) : (
-        sermons && (
-          <>
-            <SermonsList sermons={sermons.docs.map((doc) => doc.data())} />
-            {(sermons.size ?? 0) - previousSermonsCount === limitCount && (
-              <Button
-                onClick={() => {
-                  setQueryLimit((previousLimit) => previousLimit + limitCount);
-                  setPreviousSermons(sermons.docs.map((doc) => doc.data()));
-                  setPreviousSermonsCount(sermons.size);
-                }}
-              >
-                Load More
-              </Button>
-            )}
-          </>
-        )
+      {/* //   searchResults ? (
+      //   <SermonsList sermons={searchResults} />
+      // ) : ( */}
+      {sermons && (
+        <>
+          <SermonsList sermons={sermons.docs.map((doc) => doc.data())} />
+          {(sermons.size ?? 0) - previousSermonsCount === HITSPERPAGE && (
+            <Button
+              onClick={() => {
+                setQueryLimit((previousLimit) => previousLimit + HITSPERPAGE);
+                setPreviousSermons(sermons.docs.map((doc) => doc.data()));
+                setPreviousSermonsCount(sermons.size);
+              }}
+            >
+              Load More
+            </Button>
+          )}
+        </>
       )}
-      {noMoreResults && <Typography alignSelf="center">No results found</Typography>}
+      {/* {noMoreResults && <Typography alignSelf="center">No results found</Typography>} */}
     </Box>
   );
 };

--- a/functions/src/DocumentListeners/Lists/listItemOnCreate.ts
+++ b/functions/src/DocumentListeners/Lists/listItemOnCreate.ts
@@ -15,7 +15,7 @@ const listItemOnCreate = firestore
       if (!list) {
         throw new HttpsError('internal', 'Something went wrong, please try again later');
       }
-      const { count: _, listNoCount } = list;
+      const { count: _, ...listNoCount } = list;
       const batch = firestore.batch();
       batch.create(
         firestore

--- a/functions/src/DocumentListeners/Lists/listItemOnCreate.ts
+++ b/functions/src/DocumentListeners/Lists/listItemOnCreate.ts
@@ -15,6 +15,7 @@ const listItemOnCreate = firestore
       if (!list) {
         throw new HttpsError('internal', 'Something went wrong, please try again later');
       }
+      const { count: _, listNoCount } = list;
       const batch = firestore.batch();
       batch.create(
         firestore
@@ -23,7 +24,7 @@ const listItemOnCreate = firestore
           .collection('sermonLists')
           .doc(listId)
           .withConverter(firestoreAdminListConverter),
-        list
+        listNoCount
       );
       batch.update(firestore.doc(`lists/${listId}`).withConverter(firestoreAdminListConverter), {
         count: FieldValue.increment(1),

--- a/functions/src/DocumentListeners/Lists/listOnUpdate.ts
+++ b/functions/src/DocumentListeners/Lists/listOnUpdate.ts
@@ -9,9 +9,11 @@ const listOnUpdate = firestore.document('lists/{listId}').onUpdate(async (change
   logger.log('listOnUpdate triggered for: ', listId);
   const updatedList = change.after.data();
   const firestore = firebaseAdmin.firestore();
-  const { count: _countBefore, ...originalListNoCount } = change.before.data();
+  const originalList = change.before.data();
+  const { count: _countBefore, ...originalListNoCount } = originalList;
   const { count: _countAfter, ...updatedListNoCount } = updatedList;
   const onlyCountUpdated = isEqual(originalListNoCount, updatedListNoCount);
+  logger.debug('Original list vs updated list for list id: ', listId, originalList, updatedList);
   if (onlyCountUpdated) {
     logger.log(`The count was the only property that changed for ${listId}. Returning early`);
     return;
@@ -20,7 +22,6 @@ const listOnUpdate = firestore.document('lists/{listId}').onUpdate(async (change
     // update all series instances of sermon
 
     logger.log('Updating list: ', listId, ' in all sermon series');
-    logger.log('Updated list: ', updatedList);
     const sermonListSnapshot = await firestore
       .collectionGroup('sermonLists')
       .withConverter(firestoreAdminSermonListConverter)

--- a/functions/src/DocumentListeners/Lists/listOnUpdate.ts
+++ b/functions/src/DocumentListeners/Lists/listOnUpdate.ts
@@ -7,13 +7,14 @@ import handleError from '../../handleError';
 const listOnUpdate = firestore.document('lists/{listId}').onUpdate(async (change, context) => {
   const { listId } = context.params;
   logger.log('listOnUpdate triggered for: ', listId);
+  const originalList = change.before.data();
   const updatedList = change.after.data();
   const firestore = firebaseAdmin.firestore();
-  const originalList = change.before.data();
   const { count: _countBefore, ...originalListNoCount } = originalList;
   const { count: _countAfter, ...updatedListNoCount } = updatedList;
   const onlyCountUpdated = isEqual(originalListNoCount, updatedListNoCount);
-  logger.debug('Original list vs updated list for list id: ', listId, originalList, updatedList);
+  logger.debug('Original list: ', originalList);
+  logger.debug('Updated list: ', updatedList);
   if (onlyCountUpdated) {
     logger.log(`The count was the only property that changed for ${listId}. Returning early`);
     return;

--- a/functions/src/DocumentListeners/Sermons/sermonWriteTrigger.ts
+++ b/functions/src/DocumentListeners/Sermons/sermonWriteTrigger.ts
@@ -1,5 +1,6 @@
 import { DocumentData, QuerySnapshot } from 'firebase-admin/firestore';
 import { firestore, logger } from 'firebase-functions/v2';
+import { isEqual } from 'lodash';
 import firebaseAdmin from '../../../../firebase/firebaseAdmin';
 import { Sermon } from '../../../../types/SermonTypes';
 import handleError from '../../handleError';
@@ -30,21 +31,50 @@ const sermonWriteTrigger = firestore.onDocumentWritten('sermons/{sermonId}', asy
 
   const sermonBefore = event.data?.before.data() as Sermon | undefined;
   const sermonAfter = event.data?.after.data() as Sermon | undefined;
+  let sermonBeforeNoCounts: Sermon | undefined = undefined;
+  let sermonAfterNoCounts: Sermon | undefined = undefined;
+  if (sermonBefore) {
+    const {
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      numberOfLists: _beforeNumberOfLists,
+      numberOfListsUploadedTo: _beforeNumberOfListsUploadedTo,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      ...rest
+    } = sermonBefore;
+    sermonBeforeNoCounts = rest;
+  }
+  if (sermonAfter) {
+    const {
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      numberOfLists: _afterNumberOfLists,
+      numberOfListsUploadedTo: _afterNumberOfListsUploadedTo,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      ...rest
+    } = sermonAfter;
+    sermonAfterNoCounts = rest;
+  }
   try {
     const seriesSermonSnapshot = await firestoreAdmin.collectionGroup('listItems').where('id', '==', sermonId).get();
     if (sermonBefore && sermonAfter) {
+      if (isEqual(sermonBeforeNoCounts, sermonAfterNoCounts)) {
+        logger.info(
+          'Sermon numberOfLists or numberOfListsUploadedTo was the only updated which does not need to propogate. Not updating list items to save on function calls'
+        );
+        return;
+      }
       // Update
       logger.info(`Sermon ${sermonId} updated`);
       // get all sermons in Sermon
       const batch = firestoreAdmin.batch();
       seriesSermonSnapshot.docs.forEach((doc) => {
-        batch.update(doc.ref, { ...sermonAfter });
+        batch.update(doc.ref, { ...sermonAfterNoCounts });
       });
       return batch.commit();
     } else if (sermonAfter) {
       // Create
       return logger.info(`Sermon ${sermonId} created`);
     } else if (sermonBefore) {
+      logger.info(`Sermon ${sermonId} deleted`);
       return handleDelete(seriesSermonSnapshot, sermonId);
     }
   } catch (error) {

--- a/pages/admin/lists.tsx
+++ b/pages/admin/lists.tsx
@@ -179,7 +179,7 @@ const AdminList = () => {
             <MaterialList>
               {(searchResults || list).map((l) => {
                 return (
-                  <Link href={`/admin/lists/${l.id}?count=${l.count}`} key={l.id}>
+                  <Link href={`/admin/lists/${l.id}?count=${l.count || 20}`} key={l.id}>
                     <ListItemButton sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                       <Box display="flex" alignItems="center" gap={1}>
                         <AvatarWithDefaultImage
@@ -190,7 +190,7 @@ const AdminList = () => {
                           borderRadius={5}
                         />
                         <Typography>{l.name}</Typography>
-                        <Typography>{`Count: ${l.count}`}</Typography>
+                        {l.count !== undefined && <Typography>{`Count: ${l.count}`}</Typography>}
                         <Typography>{`Type: ${l.type}`}</Typography>
                       </Box>
                       <Box>

--- a/types/List.ts
+++ b/types/List.ts
@@ -35,7 +35,7 @@ export interface List {
   name: string;
   images: ImageType[];
   overflowBehavior: OverflowBehavior;
-  count: number;
+  count?: number;
   type: ListType;
   updatedAtMillis: number;
   createdAtMillis: number;

--- a/types/List.ts
+++ b/types/List.ts
@@ -37,7 +37,7 @@ export interface List {
   overflowBehavior: OverflowBehavior;
   count?: number;
   type: ListType;
-  updatedAtMillis: number;
+  updatedAtMillis?: number;
   createdAtMillis: number;
   subsplashId?: string;
   moreSermonsRef?: string;

--- a/types/SermonTypes.ts
+++ b/types/SermonTypes.ts
@@ -34,8 +34,8 @@ export interface Sermon {
   dateString?: string;
   status: sermonStatus;
   images: ImageType[];
-  numberOfLists: number;
-  numberOfListsUploadedTo: number;
+  numberOfLists?: number;
+  numberOfListsUploadedTo?: number;
   subsplashId?: string;
   soundCloudTrackId?: string;
   uploaderId?: string;


### PR DESCRIPTION
## Problem
Updates to the list count are causing many sermonLists to be updated every time a sermon is added to a list. This is because each sermonList contained a record of the lists it was in and when the count was increased in the lists document all sermonList documents which contained that list would also need to be updated

## Solution
Since there is no need for the count information to be queried when seeing which lists a sermon is in, we can make the count optional and only include it in the list itself. Then when we check if the list is updated we can ignore updating any sermonList if the only change is the count. 