### PR TITLE
feat: migrate deleteFromSubsplash to Firebase Functions v2 and fix permissions

### DIFF
--- a/components/SermonCardAdminControls.tsx
+++ b/components/SermonCardAdminControls.tsx
@@ -18,6 +18,7 @@ import { sermonConverter } from '../types/Sermon';
 import SermonCardAdminControlsComponent from './SermonCardAdminControlsComponent';
 import { getSquareImageStoragePath } from '../utils/utils';
 import { sermonListConverter } from '../types/SermonList';
+import { DeleteFromSubsplashInputType, DeleteFromSubsplashReturnType } from '../functions/src/deleteFromSubsplash';
 
 export interface AdminControlsProps {
   sermon: Sermon;
@@ -84,10 +85,10 @@ const AdminControls: FunctionComponent<AdminControlsProps> = ({
   }, [sermon.id, sermon.status]);
 
   const deleteFromSubsplashErrorThrowable = useCallback(async () => {
-    const deleteFromSubsplashCall = createFunctionV2<string, void>('deletefromsubsplash');
+    const deleteFromSubsplashCall = createFunctionV2<DeleteFromSubsplashInputType, DeleteFromSubsplashReturnType>('deletefromsubsplash');
     try {
       setIsUploadingToSubsplash(true);
-      await deleteFromSubsplashCall(sermon.subsplashId!);
+      await deleteFromSubsplashCall({ subsplashId: sermon.subsplashId! });
       await handleFirestoreDeleteFromSubsplash();
       setIsUploadingToSubsplash(false);
     } catch (error: any) {

--- a/components/SermonCardAdminControls.tsx
+++ b/components/SermonCardAdminControls.tsx
@@ -11,7 +11,7 @@ import firestore, {
 } from '../firebase/firestore';
 
 import { UploadToSoundCloudInputType, UploadToSoundCloudReturnType } from '../functions/src/uploadToSoundCloud';
-import { createFunction, createFunctionV2 } from '../utils/createFunction';
+import { createFunctionV2 } from '../utils/createFunction';
 
 import { Sermon, uploadStatus } from '../types/SermonTypes';
 import { sermonConverter } from '../types/Sermon';
@@ -84,7 +84,7 @@ const AdminControls: FunctionComponent<AdminControlsProps> = ({
   }, [sermon.id, sermon.status]);
 
   const deleteFromSubsplashErrorThrowable = useCallback(async () => {
-    const deleteFromSubsplashCall = createFunction<string, void>('deleteFromSubsplash');
+    const deleteFromSubsplashCall = createFunctionV2<string, void>('deletefromsubsplash');
     try {
       setIsUploadingToSubsplash(true);
       await deleteFromSubsplashCall(sermon.subsplashId!);

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -41,6 +41,52 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "lists",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "listTagAndPosition.listTag",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "listTagAndPosition.year",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "listTagAndPosition.position",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "lists",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "listTagAndPosition.listTag",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "listTagAndPosition.position",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "sermons",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "uploaderId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAtMillis",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": [
@@ -87,6 +133,29 @@
         {
           "order": "ASCENDING",
           "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "listItems",
+      "fieldPath": "createdAtMillis",
+      "ttl": false,
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
         }
       ]
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -47,13 +47,10 @@ service cloud.firestore {
       allow write: if (canUpload());
     }
     
-  // Allow read access for admins
+    
+    // Sermon permissions: Admins have full access, uploaders/publishers can manage their own sermons
     match /sermons/{sermonId} {
       allow read, write: if isAdmin();
-    }
-    
-    // Allow read access for uploaders to their own sermons
-    match /sermons/{sermonId} {
       allow read: if resource == null || (canUpload() && resource.data.uploaderId == request.auth.uid);
       allow update, delete: if canUpload() && resource.data.uploaderId == request.auth.uid && resource.data.status.soundCloud != 'UPLOADED' && resource.data.status.subsplash != 'UPLOADED';
       allow create: if canUpload();

--- a/firestore.rules
+++ b/firestore.rules
@@ -51,8 +51,8 @@ service cloud.firestore {
     // Sermon permissions: Admins have full access, uploaders/publishers can manage their own sermons
     match /sermons/{sermonId} {
       allow read, write: if isAdmin();
-      allow read: if resource == null || (canUpload() && resource.data.uploaderId == request.auth.uid);
-      allow update, delete: if canUpload() && resource.data.uploaderId == request.auth.uid && resource.data.status.soundCloud != 'UPLOADED' && resource.data.status.subsplash != 'UPLOADED';
+      allow read, update: if resource == null || (canUpload() && resource.data.uploaderId == request.auth.uid);
+      allow delete: if canUpload() && resource.data.uploaderId == request.auth.uid && (resource.data.status.soundCloud != 'UPLOADED' && resource.data.status.subsplash != 'UPLOADED');
       allow create: if canUpload();
     }
 

--- a/functions/src/deleteFromSubsplash.ts
+++ b/functions/src/deleteFromSubsplash.ts
@@ -5,7 +5,13 @@ import { authenticateSubsplash, createAxiosConfig } from './subsplashUtils';
 import { canUserRolePublish } from '../../types/User';
 import handleError from './handleError';
 
-const deleteFromSubsplash = onCall(async (request: CallableRequest<string>): Promise<string | number> => {
+export interface DeleteFromSubsplashInputType {
+  subsplashId: string;
+}
+
+export type DeleteFromSubsplashReturnType = void;
+
+const deleteFromSubsplash = onCall(async (request: CallableRequest<DeleteFromSubsplashInputType>): Promise<DeleteFromSubsplashReturnType> => {
   logger.log('deleteFromSubsplash', request);
 
   // Authentication check
@@ -14,7 +20,7 @@ const deleteFromSubsplash = onCall(async (request: CallableRequest<string>): Pro
   }
 
   // Input validation
-  if (!request.data || typeof request.data !== 'string' || request.data.trim() === '') {
+  if (!request.data || typeof request.data !== 'object' || !request.data.subsplashId || request.data.subsplashId.trim() === '') {
     throw new HttpsError('invalid-argument', 'The function must be called with a valid media item ID.');
   }
 
@@ -23,7 +29,8 @@ const deleteFromSubsplash = onCall(async (request: CallableRequest<string>): Pro
     throw new HttpsError('failed-precondition', 'Email or Password are not set in .env file');
   }
 
-  const mediaItemId = request.data.trim();
+  const mediaItemId = request.data.subsplashId.trim();
+  console.log('Attempting to delete mediaItemId', mediaItemId);
   const url = `https://core.subsplash.com/media/v1/media-items/${mediaItemId}`;
   logger.log(`Attempting to delete media item: ${mediaItemId} from "${url}"`);
 
@@ -34,7 +41,7 @@ const deleteFromSubsplash = onCall(async (request: CallableRequest<string>): Pro
 
     const response = await axios(config);
     logger.log('Successfully deleted media item', { mediaItemId, status: response.status });
-    return 1;
+    return;
   } catch (error) {
     logger.error('Error deleting from Subsplash', { mediaItemId, error });
 
@@ -46,6 +53,7 @@ const deleteFromSubsplash = onCall(async (request: CallableRequest<string>): Pro
       if (subsplashError?.code === 'resource_not_found') {
         code = 'not-found';
         logger.warn(`Media item not found: ${mediaItemId}`);
+        return;
       } else if (subsplashError?.code === 'unauthorized') {
         code = 'unauthenticated';
       } else if (subsplashError?.code === 'forbidden') {

--- a/functions/src/deleteFromSubsplash.ts
+++ b/functions/src/deleteFromSubsplash.ts
@@ -1,36 +1,68 @@
 import axios, { isAxiosError } from 'axios';
-import { logger, https } from 'firebase-functions';
-import { HttpsError, FunctionsErrorCode } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions/v2';
+import { CallableRequest, HttpsError, FunctionsErrorCode, onCall } from 'firebase-functions/v2/https';
 import { authenticateSubsplash, createAxiosConfig } from './subsplashUtils';
 import { canUserRolePublish } from '../../types/User';
-const deleteFromSubsplash = https.onCall(async (data: string, context): Promise<HttpsError | string | number> => {
-  if (!canUserRolePublish(context.auth?.token.role)) {
-    return 'Not Authorized';
+import handleError from './handleError';
+
+const deleteFromSubsplash = onCall(async (request: CallableRequest<string>): Promise<string | number> => {
+  logger.log('deleteFromSubsplash', request);
+
+  // Authentication check
+  if (!canUserRolePublish(request.auth?.token.role)) {
+    throw new HttpsError('unauthenticated', 'The function must be called while authenticated.');
   }
+
+  // Input validation
+  if (!request.data || typeof request.data !== 'string' || request.data.trim() === '') {
+    throw new HttpsError('invalid-argument', 'The function must be called with a valid media item ID.');
+  }
+
+  // Environment validation
   if (process.env.EMAIL == undefined || process.env.PASSWORD == undefined) {
-    return 'Email or Password are not set in .env file';
+    throw new HttpsError('failed-precondition', 'Email or Password are not set in .env file');
   }
-  const url = `https://core.subsplash.com/media/v1/media-items/${data}`;
-  logger.log(`Calling delete on "${url}"`);
+
+  const mediaItemId = request.data.trim();
+  const url = `https://core.subsplash.com/media/v1/media-items/${mediaItemId}`;
+  logger.log(`Attempting to delete media item: ${mediaItemId} from "${url}"`);
+
   try {
     const bearerToken = await authenticateSubsplash();
     const config = createAxiosConfig(url, bearerToken, 'DELETE');
     logger.debug('config', config);
-    await axios(config);
+
+    const response = await axios(config);
+    logger.log('Successfully deleted media item', { mediaItemId, status: response.status });
     return 1;
   } catch (error) {
-    //TODO[1]: Handle errors better
-    let httpsError = new HttpsError('unknown', 'Unknown error');
-    if (isAxiosError(error)) {
-      const response = error.response?.data.errors[0];
-      let code: FunctionsErrorCode = 'unknown';
-      if (response.code === 'resource_not_found') {
+    logger.error('Error deleting from Subsplash', { mediaItemId, error });
+
+    // Handle specific Subsplash API errors
+    if (isAxiosError(error) && error.response?.data?.errors) {
+      const subsplashError = error.response.data.errors[0];
+      let code: FunctionsErrorCode = 'internal';
+
+      if (subsplashError?.code === 'resource_not_found') {
         code = 'not-found';
+        logger.warn(`Media item not found: ${mediaItemId}`);
+      } else if (subsplashError?.code === 'unauthorized') {
+        code = 'unauthenticated';
+      } else if (subsplashError?.code === 'forbidden') {
+        code = 'permission-denied';
       }
-      httpsError = new HttpsError(code, error.message, response.detail);
+
+      const httpsError = new HttpsError(
+        code,
+        subsplashError?.detail || error.message || 'Failed to delete from Subsplash',
+        subsplashError
+      );
+      throw httpsError;
     }
-    logger.error(httpsError);
-    throw httpsError;
+
+    // Use the standard error handler for all other errors
+    throw handleError(error);
   }
 });
+
 export default deleteFromSubsplash;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -48,7 +48,7 @@ import { updateSubsplashTag } from './Scrapers/updateSubsplashTag';
 exports.uploadToSubsplash = uploadToSubsplash;
 exports.editSubsplashSermon = editSubsplashSermon;
 exports.editSoundCloudSermon = editSoundCloudSermon;
-exports.deleteFromSubsplash = deleteFromSubsplash;
+exports.deletefromsubsplash = deleteFromSubsplash;
 exports.setuserrole = setuserrole;
 exports.addintrooutrotaskhandler = addintrooutrotaskhandler;
 exports.addintrooutrotaskgenerator = addintrooutrotaskgenerator;


### PR DESCRIPTION
## Summary
Migrates the `deleteFromSubsplash` Cloud Function from Firebase Functions v1 to v2 and fixes related Firestore permission issues that were preventing sermon deletion cleanup.
