### PR TITLE
Fix SoundCloud upload OOMs by raising callable memory

### DIFF
--- a/functions/src/test/soundcloud/uploadToSoundCloud.config.test.ts
+++ b/functions/src/test/soundcloud/uploadToSoundCloud.config.test.ts
@@ -1,0 +1,51 @@
+describe('uploadToSoundCloud callable config', () => {
+  it('provisions extra memory for the SoundCloud upload callable', async () => {
+    const onCallMock = jest.fn((_options: unknown, handler: unknown) => handler);
+
+    jest.resetModules();
+    jest.doMock('firebase-functions/v2/https', () => {
+      const actual = jest.requireActual('firebase-functions/v2/https');
+      return {
+        ...actual,
+        onCall: onCallMock,
+      };
+    });
+    jest.doMock('../../soundcloudSecrets', () => ({
+      runWithSoundCloudAccessToken: jest.fn(),
+      soundcloudSecretsWithRuntimeAlerts: ['soundcloud-client-id'],
+    }));
+    jest.doMock('@upperroom/shared/firebase/firebaseAdmin', () => ({
+      __esModule: true,
+      default: {
+        storage: () => ({
+          bucket: jest.fn(),
+        }),
+      },
+    }));
+    jest.doMock('../../soundcloudClient', () => ({
+      normalizeSoundCloudApiError: jest.fn(),
+      uploadTrack: jest.fn(),
+    }));
+    jest.doMock('../../notifications/emitOperationalAlert', () => ({
+      emitOperationalAlert: jest.fn(),
+    }));
+    jest.doMock('../../soundcloudAuthAlerting', () => ({
+      emitSoundCloudReconnectAlertIfNeeded: jest.fn(),
+    }));
+    jest.doMock('../../sentry', () => ({
+      startFunctionsSpan: jest.fn(),
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      await import('../../uploadToSoundCloud');
+    });
+
+    expect(onCallMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memory: '512MiB',
+        secrets: ['soundcloud-client-id'],
+      }),
+      expect.any(Function)
+    );
+  });
+});

--- a/functions/src/uploadToSoundCloud.ts
+++ b/functions/src/uploadToSoundCloud.ts
@@ -25,7 +25,11 @@ export type UploadToSoundCloudReturnType = {
 };
 
 const uploadToSoundCloudCall = onCall(
-  { secrets: soundcloudSecretsWithRuntimeAlerts },
+  {
+    // Production OOMs occurred at 258-272 MiB while streaming multipart uploads.
+    memory: '512MiB',
+    secrets: soundcloudSecretsWithRuntimeAlerts,
+  },
   async (request: CallableRequest<UploadToSoundCloudInputType>): Promise<UploadToSoundCloudReturnType> => {
     if (!canUserRolePublish(request.auth?.token.role)) {
       throw new HttpsError('unauthenticated', 'The function must be called while authenticated.');


### PR DESCRIPTION
## Summary
This PR fixes production `uploadtosoundcloud` OOMs by explicitly provisioning the callable at `512MiB`.

The implementation is intentionally narrow:
- set `memory: '512MiB'` on `uploadToSoundCloud`
- add a config test to lock that runtime setting in place
- preserve existing SoundCloud reconnect handling and runtime alerting behavior

## Root cause
Production `gcloud` logs in project `urm-app` showed repeated Cloud Run instance deaths for `uploadtosoundcloud` with:
- `Memory limit of 256 MiB exceeded`
- observed usage at `258-272 MiB`
- matching HTTP `500` responses

The upload path was already using streamed multipart logic, so the confirmed failure mode was insufficient memory allocation rather than a broken reconnect/error path.

## Verification
I independently re-ran these commands in the isolated worktree before opening this PR:

```bash
./scripts/with-node22.sh pnpm --dir functions exec jest --watchman=false --runInBand src/test/soundcloud/uploadToSoundCloud.config.test.ts src/test/soundcloud/soundcloudClient.test.ts
```

```bash
pnpm --dir functions exec firebase emulators:exec --only auth,firestore,database --config ../firebase.test.json "pnpm exec jest --watchman=false --runInBand --forceExit src/test/soundcloud/uploadToSoundCloud.test.ts src/test/notifications/runtimeAlerts.test.ts"
```

Both passed.

## Residual risk
This is a provisioning fix, not a live deployment validation. After merge/deploy, the first thing to confirm is that `uploadtosoundcloud` no longer OOMs under the same workload and that runtime headroom remains acceptable.