### PR TITLE
Fix process-audio deployment retries

### DIFF
--- a/apps/process-audio/Dockerfile
+++ b/apps/process-audio/Dockerfile
@@ -142,6 +142,11 @@ COPY --from=build --chown=node:node /workspace/node_modules ./node_modules
 COPY --from=build --chown=node:node /workspace/packages ./packages
 COPY --from=build --chown=node:node /workspace/apps/process-audio ./apps/process-audio
 
+# Keep Google OAuth token fetches uncompressed. On the Hetzner runtime, gtoken's
+# node-fetch transport can intermittently fail compressed token responses with
+# ERR_STREAM_PREMATURE_CLOSE, which blocks deferred YouTube queue recovery.
+RUN node -e "const fs = require('node:fs'); const file = '/workspace/node_modules/gtoken/build/src/index.js'; const needle = \"headers: { 'Content-Type': 'application/x-www-form-urlencoded' },\"; const replacement = \"headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept-Encoding': 'identity' },\"; let source = fs.readFileSync(file, 'utf8'); if (!source.includes(replacement)) { if (!source.includes(needle)) { throw new Error('Unable to patch gtoken token request headers'); } source = source.replace(needle, replacement); fs.writeFileSync(file, source); }"
+
 # The final image should not depend on pnpm's workspace symlink layout surviving
 # multi-stage copies. Flatten the two local workspace packages into the app-local
 # node_modules tree so Node can resolve exported subpaths reliably at runtime.

--- a/apps/process-audio/cloudbuild.yaml
+++ b/apps/process-audio/cloudbuild.yaml
@@ -32,11 +32,43 @@ steps:
 
   # Step 2: Push Docker image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_AR_REPO}/${_IMAGE_NAME}:${COMMIT_SHA}']
+    entrypoint: bash
+    args:
+      - -ceu
+      - |
+        image="${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_AR_REPO}/${_IMAGE_NAME}:${COMMIT_SHA}"
+        for attempt in 1 2 3 4 5; do
+          if docker push "$${image}"; then
+            exit 0
+          fi
+
+          status="$$?"
+          if [[ "$${attempt}" == "5" ]]; then
+            exit "$${status}"
+          fi
+
+          sleep "$$((attempt * 15))"
+        done
 
   # Step 3: Refresh the shared cache tag with the freshly built image.
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_AR_REPO}/${_IMAGE_NAME}:${_CACHE_TAG}']
+    entrypoint: bash
+    args:
+      - -ceu
+      - |
+        image="${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_AR_REPO}/${_IMAGE_NAME}:${_CACHE_TAG}"
+        for attempt in 1 2 3 4 5; do
+          if docker push "$${image}"; then
+            exit 0
+          fi
+
+          status="$$?"
+          if [[ "$${attempt}" == "5" ]]; then
+            exit "$${status}"
+          fi
+
+          sleep "$$((attempt * 15))"
+        done
 
   # Step 4: Deploy the storage-only Cloud Run service.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/scripts/deploy-process-audio-hetzner.sh
+++ b/scripts/deploy-process-audio-hetzner.sh
@@ -212,16 +212,32 @@ prune_build_artifacts() {
 
 remove_service_for_rebuild() {
   local service_name="$1"
-  local image_id=""
   local container_name="process-audio-hetzner-${service_name}-1"
+  local image_ids=()
+  local container_ids=()
+  local image_id
 
-  image_id="$(docker compose images -q "$service_name" 2>/dev/null | head -n 1 || true)"
+  mapfile -t image_ids < <(docker compose images -q "$service_name" 2>/dev/null | sed '/^$/d' | sort -u || true)
+
+  docker compose stop "$service_name" >/dev/null 2>&1 || true
   docker compose rm -sf "$service_name" >/dev/null 2>&1 || true
-  docker rm -f "$container_name" >/dev/null 2>&1 || true
 
-  if [[ -n "$image_id" ]]; then
-    docker image rm -f "$image_id" >/dev/null 2>&1 || true
+  mapfile -t container_ids < <(
+    {
+      docker ps -aq --filter "name=^/${container_name}$"
+      docker ps -aq \
+        --filter "label=com.docker.compose.project=process-audio-hetzner" \
+        --filter "label=com.docker.compose.service=${service_name}"
+    } | sed '/^$/d' | sort -u
+  )
+
+  if ((${#container_ids[@]} > 0)); then
+    docker rm -f "${container_ids[@]}" >/dev/null 2>&1 || true
   fi
+
+  for image_id in "${image_ids[@]}"; do
+    docker image rm -f "$image_id" >/dev/null 2>&1 || true
+  done
 }
 
 if [[ "$target_env" == "all" ]]; then


### PR DESCRIPTION
## Summary
- remove stale Hetzner Compose containers by explicit name and Compose labels before rebuilding the process-audio service
- retry Artifact Registry docker pushes in Cloud Build to absorb transient 5xx errors like the main-branch 502 failure
- bake the gtoken Accept-Encoding workaround into process-audio images so rebuilt Hetzner workers keep recovering deferred YouTube jobs

## Verification
- bash -n scripts/deploy-process-audio-hetzner.sh
- ruby -e 'require "yaml"; YAML.load_file("apps/process-audio/cloudbuild.yaml")'\n- git diff --check\n- pnpm --dir apps/process-audio build\n- docker build -f apps/process-audio/Dockerfile --build-arg PROCESS_AUDIO_RUNTIME_PROFILE=cloudrun --target production -t process-audio-ci-fix-smoke .\n- docker run --rm --entrypoint node process-audio-ci-fix-smoke -e "...check gtoken Accept-Encoding patch..."\n\n## Main failure addressed\n- main-process-audio-hetzner-deploy failed because Compose hit a stale container-name conflict for process-audio-production\n- main-process-audio-deploy failed because Artifact Registry returned 502 during docker push\n