### PR TITLE
Suppress handled Algolia retry Sentry noise

### DIFF
--- a/apps/web/tests/utils/reportHandledError.test.ts
+++ b/apps/web/tests/utils/reportHandledError.test.ts
@@ -129,4 +129,16 @@ describe('reportHandledError helpers', () => {
 
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
+
+  it('does not bridge handled Algolia transport retry errors into Sentry', async () => {
+    const { installConsoleErrorCapture } = await import('../../utils/reportHandledError');
+
+    installConsoleErrorCapture();
+
+    const error = new Error('Unreachable hosts - the search service could not be reached.');
+    error.name = 'RetryError';
+    console.error('Search error:', error);
+
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/utils/sentryNoise.test.ts
+++ b/apps/web/tests/utils/sentryNoise.test.ts
@@ -104,4 +104,17 @@ describe('shouldDropClientSentryEvent', () => {
       })
     ).toBe(true);
   });
+
+  it('drops handled Algolia transport retry errors', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [{ type: 'RetryError', value: 'Unreachable hosts - the search service could not be reached.' }],
+        },
+        tags: {
+          'error.surface': 'handled-ui',
+        },
+      })
+    ).toBe(true);
+  });
 });

--- a/apps/web/utils/reportHandledError.ts
+++ b/apps/web/utils/reportHandledError.ts
@@ -52,13 +52,24 @@ const isFirebaseInstallationsNoise = (value: unknown): boolean => {
   return code === 'installations/request-failed' || message.includes('installations/request-failed');
 };
 
+const isAlgoliaTransportRetryError = (value: unknown): boolean => {
+  if (!isObjectRecord(value) && !(value instanceof Error)) {
+    return false;
+  }
+
+  const name = value instanceof Error ? value.name : value.name;
+  const message = getErrorMessage(value);
+  return name === 'RetryError' && message.includes('Unreachable hosts');
+};
+
 const shouldSkipConsoleCapture = (args: unknown[]): boolean => {
   const [firstArg] = args;
 
   return (
     (typeof firstArg === 'string' && FIREBASE_LOGGER_PATTERN.test(firstArg)) ||
     args.some(isLockBusyError) ||
-    args.some(isFirebaseInstallationsNoise)
+    args.some(isFirebaseInstallationsNoise) ||
+    (firstArg === 'Search error:' && args.some(isAlgoliaTransportRetryError))
   );
 };
 

--- a/apps/web/utils/sentryNoise.ts
+++ b/apps/web/utils/sentryNoise.ts
@@ -80,5 +80,13 @@ export const shouldDropClientSentryEvent = (event: Event): boolean => {
     return true;
   }
 
+  if (
+    exceptionType === 'RetryError' &&
+    exceptionValue.includes('Unreachable hosts') &&
+    getTagValue(event, 'error.surface') === 'handled-ui'
+  ) {
+    return true;
+  }
+
   return false;
 };


### PR DESCRIPTION
## Summary
- suppress handled Algolia transport RetryError console captures from the browser console Sentry bridge
- add a beforeSend drop rule for already-normalized handled Algolia retry events
- cover both paths with focused Jest tests

## Sentry evidence
- Investigated WEB-APP-1B in `web-app`: RetryError from `apps/web/components/uploaderComponents/SpeakerSelector.tsx` during rapid speaker search.
- Event breadcrumbs showed repeated zero-status Algolia XHRs in one mobile session, followed by `console.error("Search error:", error)`.
- The app already handles this path by returning an empty result set; the root reporting bug was the console bridge turning that expected transient search transport failure into a handled-ui Sentry error.

## Verification
- `PATH="/tmp/codex-corepack-bin:/Users/yasaad/.nvm/versions/node/v22.22.0/bin:$PATH" ./scripts/with-node22.sh pnpm run build:packages`
- `PATH="/tmp/codex-corepack-bin:/Users/yasaad/.nvm/versions/node/v22.22.0/bin:$PATH" ./scripts/with-node22.sh pnpm --dir apps/web exec jest tests/utils/reportHandledError.test.ts tests/utils/sentryNoise.test.ts --config jest.config.js --watchman=false --runInBand`
- `PATH="/tmp/codex-corepack-bin:/Users/yasaad/.nvm/versions/node/v22.22.0/bin:$PATH" ./scripts/with-node22.sh pnpm test`
