### PR TITLE
Handle SoundCloud upload validation errors

### DIFF
--- a/functions/src/soundcloudClient.ts
+++ b/functions/src/soundcloudClient.ts
@@ -10,6 +10,7 @@ import axios, { AxiosError, isAxiosError } from 'axios';
 import FormData from 'form-data';
 import { Bucket } from '@google-cloud/storage';
 import { createSoundCloudReconnectRequiredError } from './soundcloudAuthErrors';
+import { HttpsError } from 'firebase-functions/v2/https';
 import { basename, extname } from 'node:path';
 import { Readable } from 'node:stream';
 
@@ -47,6 +48,17 @@ export const normalizeSoundCloudApiError = (error: unknown): never => {
   if (isAxiosError(error) && error.response?.status === 401) {
     throw createSoundCloudReconnectRequiredError(
       'SoundCloud authorization is missing or expired. Reconnect SoundCloud from Admin > Advanced and try again.'
+    );
+  }
+
+  if (isAxiosError(error) && error.response?.status === 400) {
+    throw new HttpsError(
+      'invalid-argument',
+      'SoundCloud rejected the track upload. Check the title, description, tags, artwork, and audio file, then try again.',
+      {
+        code: 'SOUNDCLOUD_UPLOAD_REJECTED',
+        upstream_status: 400,
+      }
     );
   }
 

--- a/functions/src/test/soundcloud/soundcloudClientErrors.test.ts
+++ b/functions/src/test/soundcloud/soundcloudClientErrors.test.ts
@@ -1,0 +1,34 @@
+import { AxiosError } from 'axios';
+import { normalizeSoundCloudApiError } from '../../soundcloudClient';
+
+describe('soundcloudClient error normalization', () => {
+  it('normalizes SoundCloud upload validation failures without leaking upstream response data', () => {
+    const error = new AxiosError('Request failed with status code 400', 'ERR_BAD_REQUEST', undefined, undefined, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: {},
+      config: { headers: {} } as never,
+      data: {
+        errors: [
+          {
+            field: 'asset_data',
+            message: 'synthetic upstream validation detail',
+          },
+        ],
+      },
+    });
+
+    try {
+      normalizeSoundCloudApiError(error);
+      throw new Error('Expected normalizeSoundCloudApiError to throw');
+    } catch (normalizedError) {
+      const httpsError = normalizedError as { code?: string; message?: string; details?: unknown };
+      expect(httpsError.code).toBe('invalid-argument');
+      expect(httpsError.message).toContain('SoundCloud rejected the track upload');
+      expect(httpsError.details).toEqual({
+        code: 'SOUNDCLOUD_UPLOAD_REJECTED',
+        upstream_status: 400,
+      });
+    }
+  });
+});

--- a/functions/src/test/soundcloud/uploadToSoundCloud.test.ts
+++ b/functions/src/test/soundcloud/uploadToSoundCloud.test.ts
@@ -4,6 +4,12 @@ import {
 } from './mocks';
 import uploadToSoundCloud from '../../uploadToSoundCloud';
 import type { UploadToSoundCloudInputType, UploadToSoundCloudReturnType } from '../../uploadToSoundCloud';
+import { HttpsError } from 'firebase-functions/v2/https';
+import { emitOperationalAlert } from '../../notifications/emitOperationalAlert';
+
+jest.mock('../../notifications/emitOperationalAlert', () => ({
+  emitOperationalAlert: jest.fn(async () => undefined),
+}));
 
 const handler = uploadToSoundCloud as unknown as (req: {
   auth?: { token?: { role?: string } };
@@ -104,25 +110,60 @@ describe('uploadToSoundCloud', () => {
   it('surfaces invalid SoundCloud credentials as failed-precondition', async () => {
     mockUploadTrack.mockRejectedValue(new Error('Request failed with status code 401'));
     mockNormalizeSoundCloudApiError.mockImplementation(() => {
-      throw Object.assign(new Error('Invalid SoundCloud token'), { code: 'failed-precondition' });
+      throw new HttpsError('failed-precondition', 'Invalid SoundCloud token');
     });
 
-    await handler({
-      auth: { token: { role: 'admin' } },
-      data: {
-        audioStoragePath: 'intro-outro-sermons/sermon-1',
-        title: 'Test',
-        speakers: [],
-        tags: [],
-        description: '',
+    await expect(
+      handler({
+        auth: { token: { role: 'admin' } },
+        data: {
+          audioStoragePath: 'intro-outro-sermons/sermon-1',
+          title: 'Test',
+          speakers: [],
+          tags: [],
+          description: '',
+        },
+      })
+    ).rejects.toMatchObject({
+      code: 'failed-precondition',
+      message: 'Invalid SoundCloud token',
+    });
+  });
+
+  it('surfaces SoundCloud upload validation failures without emitting a runtime alert', async () => {
+    const validationError = new HttpsError(
+      'invalid-argument',
+      'SoundCloud rejected the track upload. Check the title, description, tags, artwork, and audio file, then try again.',
+      {
+        code: 'SOUNDCLOUD_UPLOAD_REJECTED',
+        upstream_status: 400,
+      }
+    );
+    mockUploadTrack.mockRejectedValue(new Error('Request failed with status code 400'));
+    mockNormalizeSoundCloudApiError.mockImplementation(() => {
+      throw validationError;
+    });
+
+    await expect(
+      handler({
+        auth: { token: { role: 'admin' } },
+        data: {
+          audioStoragePath: 'intro-outro-sermons/sermon-validation',
+          title: 'Rejected upload',
+          speakers: ['Speaker A'],
+          tags: ['tag-a'],
+          description: 'Description.',
+          imageSource: 'https://storage.example.test/artwork.jpg',
+        },
+      })
+    ).rejects.toMatchObject({
+      code: 'invalid-argument',
+      message: expect.stringContaining('SoundCloud rejected the track upload'),
+      details: {
+        code: 'SOUNDCLOUD_UPLOAD_REJECTED',
+        upstream_status: 400,
       },
-      })
-      .then(() => {
-        throw new Error('Expected handler to reject');
-      })
-      .catch((error: { code?: string; message?: string }) => {
-        expect(error.code).toBe('internal');
-        expect(error.message).toBe('Invalid SoundCloud token');
-      });
+    });
+    expect(emitOperationalAlert).not.toHaveBeenCalled();
   });
 });

--- a/functions/src/uploadToSoundCloud.ts
+++ b/functions/src/uploadToSoundCloud.ts
@@ -31,6 +31,15 @@ const isTransientUpstreamError = (error: unknown): error is AxiosError =>
   error.response.status >= 500 &&
   error.response.status < 600;
 
+const normalizeCaughtSoundCloudError = (error: unknown): unknown => {
+  try {
+    normalizeSoundCloudApiError(error);
+  } catch (normalizedError) {
+    return normalizedError;
+  }
+  return error;
+};
+
 const uploadToSoundCloudCall = onCall(
   {
     // Production OOMs occurred at 258-272 MiB while streaming multipart uploads.
@@ -83,9 +92,11 @@ const uploadToSoundCloudCall = onCall(
         ...(uploadResult.permalinkUrl ? { soundCloudTrackUrl: uploadResult.permalinkUrl } : {}),
       };
     } catch (error) {
-      if (error instanceof HttpsError) {
+      const normalizedError = normalizeCaughtSoundCloudError(error);
+
+      if (normalizedError instanceof HttpsError) {
         await emitSoundCloudReconnectAlertIfNeeded({
-          error,
+          error: normalizedError,
           alertCode: 'PUBLISH_SOUNDCLOUD_UPLOAD_RUNTIME_FAILURE',
           summary: 'uploadToSoundCloud callable requires SoundCloud re-authorization.',
           context: {
@@ -93,15 +104,15 @@ const uploadToSoundCloudCall = onCall(
             audioStoragePath: data.audioStoragePath,
           },
         });
-        throw error;
+        throw normalizedError;
       }
 
-      if (isTransientUpstreamError(error)) {
+      if (isTransientUpstreamError(normalizedError)) {
         logger.warn('uploadToSoundCloud transient upstream failure', {
-          status: error.response?.status,
+          status: normalizedError.response?.status,
           audioStoragePath: data.audioStoragePath,
         });
-        throw handleError(error, {
+        throw handleError(normalizedError, {
           suppressReporting: true,
           context: {
             functionName: 'uploadToSoundCloud',
@@ -113,25 +124,13 @@ const uploadToSoundCloudCall = onCall(
       await emitOperationalAlert({
         alertCode: 'PUBLISH_SOUNDCLOUD_UPLOAD_RUNTIME_FAILURE',
         summary: 'uploadToSoundCloud callable failed during publish upload flow.',
-        error: (() => {
-          try {
-            normalizeSoundCloudApiError(error);
-          } catch (normalizedError) {
-            return normalizedError;
-          }
-          return error;
-        })(),
+        error: normalizedError,
         context: {
           functionName: 'uploadToSoundCloud',
           audioStoragePath: data.audioStoragePath,
         },
       });
-      try {
-        normalizeSoundCloudApiError(error);
-      } catch (normalizedError) {
-        throw handleError(normalizedError);
-      }
-      throw handleError(error);
+      throw handleError(normalizedError);
     }
   }
 );


### PR DESCRIPTION
## Summary
- Normalize SoundCloud HTTP 400 upload rejections to an expected `invalid-argument` callable error.
- Normalize before the upload callable emits runtime operational alerts, so expected SoundCloud validation failures do not create Sentry noise.
- Add focused tests for the SoundCloud normalizer and upload callable alert behavior.

## Root Cause
Sentry `FIREBASE-FUNCTIONS-D` / `WEB-APP-15` showed production SoundCloud uploads where Firebase Storage audio and artwork downloads succeeded, then `POST https://api.soundcloud.com/tracks` returned 400. The upload callable emitted an operational alert before normalizing the SoundCloud API error, so a client-side upstream validation rejection was captured as an unexpected runtime failure and surfaced to the frontend as a generic Firebase internal error.

## Validation
- `pnpm --dir functions exec firebase emulators:exec --only auth,firestore,database,storage --config ../firebase.test.json "pnpm exec jest --watchman=false --runInBand --forceExit src/test/soundcloud/soundcloudClient.test.ts src/test/soundcloud/soundcloudClientErrors.test.ts src/test/soundcloud/uploadToSoundCloud.test.ts"`
- `pnpm test`
