### PR TITLE
Handle non-Timestamp sermon dates

### DIFF
--- a/apps/web/types/Sermon.ts
+++ b/apps/web/types/Sermon.ts
@@ -75,6 +75,50 @@ export const getDateString = (date: Date) => {
   return `${months[date.getMonth()]} ${date.getDate()}`;
 };
 
+type FirestoreTimestampLike = {
+  toMillis?: () => number;
+  toDate?: () => Date;
+  seconds?: number;
+  nanoseconds?: number;
+};
+
+export const normalizeSermonDateMillis = (date: unknown, fallbackMillis: number): number => {
+  if (date instanceof Date) {
+    const millis = date.getTime();
+    return Number.isFinite(millis) ? millis : fallbackMillis;
+  }
+
+  if (typeof date === 'number') {
+    return Number.isFinite(date) ? date : fallbackMillis;
+  }
+
+  if (typeof date === 'string') {
+    const millis = Date.parse(date);
+    return Number.isFinite(millis) ? millis : fallbackMillis;
+  }
+
+  if (date && typeof date === 'object') {
+    const timestamp = date as FirestoreTimestampLike;
+
+    if (typeof timestamp.toMillis === 'function') {
+      const millis = timestamp.toMillis();
+      return Number.isFinite(millis) ? millis : fallbackMillis;
+    }
+
+    if (typeof timestamp.toDate === 'function') {
+      const millis = timestamp.toDate().getTime();
+      return Number.isFinite(millis) ? millis : fallbackMillis;
+    }
+
+    if (typeof timestamp.seconds === 'number') {
+      const millis = timestamp.seconds * 1000 + Math.floor((timestamp.nanoseconds ?? 0) / 1_000_000);
+      return Number.isFinite(millis) ? millis : fallbackMillis;
+    }
+  }
+
+  return fallbackMillis;
+};
+
 /* This converter takes care of converting a Sermon to a FirebaseSermon on upload
  *  and a FirebaseSermon to a Sermon on download.
  */
@@ -91,13 +135,12 @@ export const sermonConverter: FirestoreDataConverter<Sermon> = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { date, ...data } = snapshot.data();
     const currentTime = Timestamp.now();
+    const dateMillis = normalizeSermonDateMillis(date, currentTime.toMillis());
     const convertedSermon: Sermon = {
       ...createEmptySermon(),
       ...data,
-      ...(snapshot.data().date && {
-        dateMillis: snapshot.data()?.date?.toMillis() || currentTime.toMillis(),
-        dateString: getDateString(snapshot.data()?.date?.toDate() || currentTime.toDate()),
-      }),
+      dateMillis,
+      dateString: getDateString(new Date(dateMillis)),
       id: snapshot.id,
     };
     if (!Object.prototype.hasOwnProperty.call(data, 'trimDurationSeconds')) {

--- a/apps/web/utils/sermonConverter.test.ts
+++ b/apps/web/utils/sermonConverter.test.ts
@@ -1,0 +1,63 @@
+import { getDateString, normalizeSermonDateMillis, sermonConverter } from '../types/Sermon';
+
+const createSnapshot = (data: Record<string, unknown>) =>
+  ({
+    id: 'sermon-id',
+    data: () => data,
+  } as never);
+
+describe('sermonConverter', () => {
+  it('reads Firestore Timestamp values without replacing epoch millis', () => {
+    const sermon = sermonConverter.fromFirestore(
+      createSnapshot({
+        title: 'Timestamp sermon',
+        date: {
+          toMillis: () => 0,
+          toDate: () => new Date(0),
+        },
+      })
+    );
+
+    expect(sermon).toMatchObject({
+      id: 'sermon-id',
+      title: 'Timestamp sermon',
+      dateMillis: 0,
+      dateString: getDateString(new Date(0)),
+    });
+  });
+
+  it('accepts plain timestamp-shaped date objects', () => {
+    const sermon = sermonConverter.fromFirestore(
+      createSnapshot({
+        title: 'Plain timestamp sermon',
+        date: {
+          seconds: 1767225600,
+          nanoseconds: 500_000_000,
+        },
+      })
+    );
+
+    expect(sermon.dateMillis).toBe(1767225600500);
+    expect(sermon.dateString).toBe(getDateString(new Date(1767225600500)));
+  });
+
+  it('accepts serialized date strings from legacy or cached data', () => {
+    const sermon = sermonConverter.fromFirestore(
+      createSnapshot({
+        title: 'Serialized date sermon',
+        date: '2026-01-15T12:00:00.000Z',
+      })
+    );
+
+    expect(sermon.dateMillis).toBe(Date.parse('2026-01-15T12:00:00.000Z'));
+    expect(sermon.dateString).toBe(getDateString(new Date('2026-01-15T12:00:00.000Z')));
+  });
+});
+
+describe('normalizeSermonDateMillis', () => {
+  it('falls back for invalid date values instead of throwing', () => {
+    expect(normalizeSermonDateMillis({ unexpected: 'shape' }, 1234)).toBe(1234);
+    expect(normalizeSermonDateMillis(undefined, 1234)).toBe(1234);
+    expect(normalizeSermonDateMillis(Number.NaN, 1234)).toBe(1234);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `sermonConverter.fromFirestore` so list item mapping does not throw when `date` is not a Firestore Timestamp instance.
- Normalize SDK Timestamp, Date, millis number, serialized string, and plain `{ seconds, nanoseconds }` timestamp-shaped values.
- Preserve epoch millis instead of replacing `0` with the current time.

## Sentry
- Fixes `WEB-APP-1C`: `TypeError: date.toMillis is not a function` on `/admin/lists/[listId]`.
- Latest observed events were production Safari events on 2026-07-25 after a successful `getlistoverflowchain` call.
- gcloud logs showed the callable returned 200; the failure happened in the client mapper while loading list details.

## Testing
- `pnpm --dir apps/web exec jest utils/sermonConverter.test.ts --config jest.config.js --runInBand`
- `pnpm test`

## Notes
- `pnpm test` needed a forced local build of `@upperroom/shared` and `@upperroom/contracts` after install because Turbo initially replayed cached builds without local emitted package files.
- `graphify update .` was run, but graph artifacts were restored because this graphify version rewrote a large non-source diff unrelated to the fix.
